### PR TITLE
Add default icon for videojs-contrib-quality-menu

### DIFF
--- a/src/quality-menu-button.js
+++ b/src/quality-menu-button.js
@@ -113,7 +113,7 @@ class QualityMenuButton extends MenuButton {
    * @method buildCSSClass
    */
   buildCSSClass() {
-    return `vjs-quality-menu-button ${super.buildCSSClass()}`;
+    return `vjs-quality-menu-button vjs-icon-cog ${super.buildCSSClass()}`;
   }
 
   /**


### PR DESCRIPTION
This PR adds the icon vjs-icon-cog so that there is a default icon shown in the control bar.

List of all the icons: https://videojs.github.io/font/

I hope it's the correct way to add this default icon, if not please tell me.

Thank you!