### PR TITLE
fix: Support videos with audio-only levels by omitting those levels

### DIFF
--- a/hls.html
+++ b/hls.html
@@ -7,10 +7,6 @@
   <link href="/dist/videojs-contrib-quality-menu.css" rel="stylesheet">
 </head>
 <body>
-  <p>
-    This demo is currently not working because the bipbop sample stream has
-    a non-video rendition included.
-  </p>
   <video-js id="player" class="vjs-fluid" controls>
     <source src="https://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8" type="application/x-mpegURL">
   </video-js>

--- a/src/quality-menu-button.js
+++ b/src/quality-menu-button.js
@@ -7,21 +7,16 @@ import QualityMenuItem from './quality-menu-item.js';
 const MenuButton = videojs.getComponent('MenuButton');
 
 /**
- * Checks whether all the QualityLevels in a QualityLevelList have resolution information
+ * Checks whether any of the QualityLevels in a QualityLevelList have resolution information
  *
  * @param {QualityLevelList} qualityLevelList
  *        The list of QualityLevels
  * @return {boolean}
- *         True if all levels have resolution information, false otherwise
+ *         True if any levels have resolution information, false if none have
  * @function hasResolutionInfo
  */
 const hasResolutionInfo = function(qualityLevelList) {
-  for (let i = 0, l = qualityLevelList.length; i < l; i++) {
-    if (!qualityLevelList[i].height) {
-      return false;
-    }
-  }
-  return true;
+  return Array.from(qualityLevelList).some((level) => level.height);
 };
 
 /**
@@ -68,6 +63,7 @@ class QualityMenuButton extends MenuButton {
     this.qualityLevels_ = player.qualityLevels();
 
     this.update = this.update.bind(this);
+
     this.handleQualityChange_ = this.handleQualityChange_.bind(this);
     this.changeHandler_ = () => {
       const defaultResolution = this.options_.defaultResolution;
@@ -188,6 +184,12 @@ class QualityMenuButton extends MenuButton {
       const level = this.qualityLevels_[i];
       const active = this.qualityLevels_.selectedIndex === i;
       const lines = level.height;
+
+      // Do not include an audio-only level
+      if (!lines) {
+        continue;
+      }
+
       let label;
 
       if (this.options_.resolutionLabelBitrates) {

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -171,6 +171,63 @@ QUnit.test('Groups QualityLevels by resolution by default', function(assert) {
   );
 });
 
+QUnit.test('Does not create menu items for audio-only levels', function(assert) {
+  this.player.qualityMenu();
+  // Tick the clock forward enough to trigger the player to be "ready".
+  this.clock.tick(1);
+
+  const levels = this.player.qualityLevels();
+  const button = this.player.getChild('controlBar').getChild('QualityMenuButton');
+
+  assert.equal(button.items.length, 0, 'no menu items when empty quality level list');
+
+  levels.addQualityLevel({
+    id: '1',
+    bandwidth: 2000001,
+    width: 500,
+    height: 500,
+    enabled: () => {}
+  });
+  levels.addQualityLevel({
+    id: '2',
+    bandwidth: 3000001,
+    width: 600,
+    height: 600,
+    enabled: () => {}
+  });
+  levels.addQualityLevel({
+    id: '3',
+    bandwidth: 19999,
+    width: 300,
+    height: 300,
+    enabled: () => {}
+  });
+  levels.addQualityLevel({
+    id: '4',
+    bandwidth: 1111,
+    width: undefined,
+    height: undefined,
+    enabled: () => {}
+  });
+
+  assert.equal(button.items.length, 4, 'created 4 menu items');
+
+  assert.equal(button.items[0].controlText(), '600p', '600p');
+  assert.deepEqual(button.items[0].levels_, [1], '600p variants added to 600p menu item');
+
+  assert.equal(button.items[1].controlText(), '500p', '500p');
+  assert.deepEqual(button.items[1].levels_, [0], '500p variants added to 500p menu item');
+
+  assert.equal(button.items[2].controlText(), '300p', '300p');
+  assert.deepEqual(button.items[2].levels_, [2], '300p variants added to 300p menu item');
+
+  assert.equal(button.items[3].controlText(), 'Auto', 'Auto');
+  assert.deepEqual(
+    button.items[3].levels_, [0, 1, 2, 3],
+    'All variants added to Auto menu item'
+  );
+});
+
 QUnit.test('Dispalys bitrate along with resolution when resolutionLabelBitrates option', function(assert) {
   this.player.qualityMenu({ resolutionLabelBitrates: true });
   // Tick the clock forward enough to trigger the player to be "ready".
@@ -244,25 +301,18 @@ QUnit.test('Falls back to grouping by bitrate when no resolution info is availab
   levels.addQualityLevel({
     id: '1',
     bandwidth: 2000001,
-    width: 500,
-    height: 500,
     enabled: () => {}
   });
   levels.addQualityLevel({
     id: '2',
     bandwidth: 3000001,
-    width: 600,
-    height: 600,
     enabled: () => {}
   });
   levels.addQualityLevel({
     id: '3',
     bandwidth: 19999,
-    width: 300,
-    height: 300,
     enabled: () => {}
   });
-  // No resolution info available in this level.
   levels.addQualityLevel({
     id: '4',
     bandwidth: 1111,


### PR DESCRIPTION
Allows for videos that have audio-only renditions.

`hasResolutionInfo()` changes from checking whether _all_ renditions have resolutions details, to checking whether _any_ do. It doesn't seem reasonable or likely to include resolution information in the manifest for some but not all video renditions.

When populating menu items, a level without a height is skipped, so it does not feature in the menu.

Updates tests to new behaviour.