### PR TITLE
fix(pkg): keep not-prerelease, needed for is-prerelease script call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "husky": "^7.0.4",
         "karma": "^6.4.2",
         "lint-staged": "^11.2.6",
+        "not-prerelease": "^1.0.1",
         "npm-merge-driver-install": "^2.0.2",
         "npm-run-all": "^4.1.5",
         "rollup": "^2.79.1",
@@ -8790,6 +8791,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/not-prerelease": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/not-prerelease/-/not-prerelease-1.0.1.tgz",
+      "integrity": "sha512-Cyia7zecBYj219nIzJBc6TmzK3Z8MzFhShF365g3YrKngBmdmr4BRaKVVvVpHOxVlk/5iqn5Dmxz4K9M3orApA==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^5.5.0"
+      },
+      "bin": {
+        "is-prerelease": "is-prerelease.js",
+        "not-prerelease": "not-prerelease.js"
       }
     },
     "node_modules/npm-merge-driver-install": {
@@ -18809,6 +18823,15 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
+    },
+    "not-prerelease": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/not-prerelease/-/not-prerelease-1.0.1.tgz",
+      "integrity": "sha512-Cyia7zecBYj219nIzJBc6TmzK3Z8MzFhShF365g3YrKngBmdmr4BRaKVVvVpHOxVlk/5iqn5Dmxz4K9M3orApA==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.5.0"
+      }
     },
     "npm-merge-driver-install": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "husky": "^7.0.4",
     "karma": "^6.4.2",
     "lint-staged": "^11.2.6",
+    "not-prerelease": "^1.0.1",
     "npm-merge-driver-install": "^2.0.2",
     "npm-run-all": "^4.1.5",
     "rollup": "^2.79.1",


### PR DESCRIPTION
🤦 

Following #5, we _do_ need the not-prerelease package.