### PR TITLE
feat: add support for Video.js experimental SVG icons

### DIFF
--- a/dash-svg.html
+++ b/dash-svg.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <video-js id="player" class="vjs-fluid" controls>
-    <source src="https://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8" type="application/x-mpegURL">
+    <source src="http://dash.edgesuite.net/akamai/bbb_30fps/bbb_30fps.mpd" type="application/dash+xml">
   </video-js>
   <ul>
     <li><a href="/hls.html">HLS Demo</a></li>
@@ -21,6 +21,7 @@
   <script src="/dist/videojs-contrib-quality-menu.js"></script>
   <script>
     const player = videojs('player', {
+      experimentalSvgIcons: true,
       plugins: {
         qualityMenu: {
           defaultResolution: '360'

--- a/dash.html
+++ b/dash.html
@@ -12,7 +12,9 @@
   </video-js>
   <ul>
     <li><a href="/hls.html">HLS Demo</a></li>
+    <li><a href="/hls-svg.html">HLS Demo using SVG Icon</a></li>
     <li><a href="/dash.html">DASH Demo</a></li>
+    <li><a href="/dash-svg.html">DASH Demo using SVG Icon</a></li>
     <li><a href="/test/debug.html">Run unit tests in browser.</a></li>
   </ul>
   <script src="/node_modules/video.js/dist/video.js"></script>

--- a/hls-svg.html
+++ b/hls-svg.html
@@ -21,6 +21,7 @@
   <script src="/dist/videojs-contrib-quality-menu.js"></script>
   <script>
     const player = videojs('player', {
+      experimentalSvgIcons: true,
       plugins: {
         qualityMenu: {
           defaultResolution: '360'

--- a/index.html
+++ b/index.html
@@ -7,7 +7,9 @@
 <body>
   <ul>
     <li><a href="/hls.html">HLS Demo</a></li>
+    <li><a href="/hls-svg.html">HLS Demo using SVG Icon</a></li>
     <li><a href="/dash.html">DASH Demo</a></li>
+    <li><a href="/dash-svg.html">DASH Demo using SVG Icon</a></li>
     <li><a href="/test/debug.html">Run unit tests in browser.</a></li>
   </ul>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "videojs-standard": "^9.0.1"
       },
       "peerDependencies": {
-        "video.js": "^8"
+        "video.js": "^8.5.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2361,6 +2361,23 @@
         "video.js": "^7 || ^8"
       }
     },
+    "node_modules/@videojs/http-streaming/node_modules/mux.js": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.2.tgz",
+      "integrity": "sha512-CM6+QuyDbc0qW1OfEjkd2+jVKzTXF+z5VOKH0eZxtZtnrG/ilkW/U7l7IXGtBNLASF9sKZMcK1u669cq50Qq0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "global": "^4.4.0"
+      },
+      "bin": {
+        "muxjs-transmux": "bin/transmux.js"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      }
+    },
     "node_modules/@videojs/vhs-utils": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.0.0.tgz",
@@ -4130,15 +4147,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/dateformat/node_modules/trim-newlines": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha512-Nm4cF79FhSTzrLKGDMi3I4utBtFv8qKy4sq1enftf2gMdpqI8oVQTAfySkTz5r49giVzDj88SVZXP4CeYQwjaw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -5723,9 +5731,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true,
       "funding": [
         {
@@ -8579,9 +8587,9 @@
       "dev": true
     },
     "node_modules/mux.js": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.2.tgz",
-      "integrity": "sha512-CM6+QuyDbc0qW1OfEjkd2+jVKzTXF+z5VOKH0eZxtZtnrG/ilkW/U7l7IXGtBNLASF9sKZMcK1u669cq50Qq0A==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.3.tgz",
+      "integrity": "sha512-gzlzJVEGFYPtl2vvEiJneSWAWD4nfYRHD5XgxmB2gWvXraMPOYk+sxfvexmNfjQUFpmk6hwLR5C6iSFmuwCHdQ==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.11.2",
@@ -11404,6 +11412,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha512-Nm4cF79FhSTzrLKGDMi3I4utBtFv8qKy4sq1enftf2gMdpqI8oVQTAfySkTz5r49giVzDj88SVZXP4CeYQwjaw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/trough": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
@@ -13967,6 +13984,18 @@
         "mpd-parser": "^1.3.0",
         "mux.js": "7.0.2",
         "video.js": "^7 || ^8"
+      },
+      "dependencies": {
+        "mux.js": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.2.tgz",
+          "integrity": "sha512-CM6+QuyDbc0qW1OfEjkd2+jVKzTXF+z5VOKH0eZxtZtnrG/ilkW/U7l7IXGtBNLASF9sKZMcK1u669cq50Qq0A==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.11.2",
+            "global": "^4.4.0"
+          }
+        }
       }
     },
     "@videojs/vhs-utils": {
@@ -15295,12 +15324,6 @@
           "requires": {
             "get-stdin": "^4.0.1"
           }
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha512-Nm4cF79FhSTzrLKGDMi3I4utBtFv8qKy4sq1enftf2gMdpqI8oVQTAfySkTz5r49giVzDj88SVZXP4CeYQwjaw==",
-          "dev": true
         }
       }
     },
@@ -16547,9 +16570,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true
     },
     "for-each": {
@@ -18648,9 +18671,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.2.tgz",
-      "integrity": "sha512-CM6+QuyDbc0qW1OfEjkd2+jVKzTXF+z5VOKH0eZxtZtnrG/ilkW/U7l7IXGtBNLASF9sKZMcK1u669cq50Qq0A==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.3.tgz",
+      "integrity": "sha512-gzlzJVEGFYPtl2vvEiJneSWAWD4nfYRHD5XgxmB2gWvXraMPOYk+sxfvexmNfjQUFpmk6hwLR5C6iSFmuwCHdQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.11.2",
@@ -20829,6 +20852,12 @@
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
       "integrity": "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==",
+      "dev": true
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha512-Nm4cF79FhSTzrLKGDMi3I4utBtFv8qKy4sq1enftf2gMdpqI8oVQTAfySkTz5r49giVzDj88SVZXP4CeYQwjaw==",
       "dev": true
     },
     "trough": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "videojs-standard": "^9.0.1"
   },
   "peerDependencies": {
-    "video.js": "^8"
+    "video.js": "^8.5.3"
   },
   "style": "dist/videojs-contrib-quality-menu.css",
   "videojs-plugin": {

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -5,31 +5,6 @@
   &.vjs-quality-menu {
     display: block;
 
-    .vjs-quality-menu-button:before {
-      font-family: VideoJS;
-      font-weight: normal;
-      font-style: normal;
-      content: "\f114";
-    }
-
-    .vjs-quality-menu-button {
-      position: initial;
-
-      &:before {
-        content: none;
-      }
-
-      .vjs-icon-placeholder {
-        font-family: VideoJS;
-        font-weight: normal;
-        font-style: normal;
-
-        &:before {
-          content: "\f114";
-        }
-      }
-    }
-
     .vjs-quality-menu-button {
       position: relative;
 

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -12,30 +12,22 @@
       content: "\f114";
     }
 
-    @mixin vjs-quality() {
-      .vjs-quality-menu-button {
-        position: initial;
+    .vjs-quality-menu-button {
+      position: initial;
+
+      &:before {
+        content: none;
+      }
+
+      .vjs-icon-placeholder {
+        font-family: VideoJS;
+        font-weight: normal;
+        font-style: normal;
 
         &:before {
-          content: none;
-        }
-
-        .vjs-icon-placeholder {
-          font-family: VideoJS;
-          font-weight: normal;
-          font-style: normal;
-
-          &:before {
-            content: "\f114";
-          }
+          content: "\f114";
         }
       }
-    }
-
-    &.vjs-v8,
-    &.vjs-v7,
-    &.vjs-v6 {
-      @include vjs-quality();
     }
 
     .vjs-quality-menu-button {

--- a/src/quality-menu-button.js
+++ b/src/quality-menu-button.js
@@ -60,7 +60,7 @@ class QualityMenuButton extends MenuButton {
     this.el_.setAttribute('aria-label', this.localize('Quality Levels'));
     this.controlText('Quality Levels');
     if (!player.options().experimentalSvgIcons) {
-      this.el().$('.vjs-icon-placeholder').classList.add('vjs-icon-cog');
+      this.$('.vjs-icon-placeholder').classList.add('vjs-icon-cog');
     }
     this.setIcon('cog');
 

--- a/src/quality-menu-button.js
+++ b/src/quality-menu-button.js
@@ -59,6 +59,7 @@ class QualityMenuButton extends MenuButton {
 
     this.el_.setAttribute('aria-label', this.localize('Quality Levels'));
     this.controlText('Quality Levels');
+    this.setIcon('cog');
 
     this.qualityLevels_ = player.qualityLevels();
 
@@ -109,7 +110,7 @@ class QualityMenuButton extends MenuButton {
    * @method buildCSSClass
    */
   buildCSSClass() {
-    return `vjs-quality-menu-button vjs-icon-cog ${super.buildCSSClass()}`;
+    return `vjs-quality-menu-button ${super.buildCSSClass()}`;
   }
 
   /**

--- a/src/quality-menu-button.js
+++ b/src/quality-menu-button.js
@@ -59,6 +59,9 @@ class QualityMenuButton extends MenuButton {
 
     this.el_.setAttribute('aria-label', this.localize('Quality Levels'));
     this.controlText('Quality Levels');
+    if (!player.options().experimentalSvgIcons) {
+      this.el().$('.vjs-icon-placeholder').classList.add('vjs-icon-cog');
+    }
     this.setIcon('cog');
 
     this.qualityLevels_ = player.qualityLevels();


### PR DESCRIPTION
Fixes #7 

This was overlooked when open sourcing since the Brightcove Player does not currently use the SVG icons.

- Adds two SVG icon test pages for comparison.
- Minor CSS cleanup
- Implements SVG icon via `setIcon` function call
- Increases minimum Video.js version to 8.5.x

This also reverts #1 as it turns out that change was not necessary.