### PR TITLE
fix: hide quality menu during ads

### DIFF
--- a/src/quality-menu-button.js
+++ b/src/quality-menu-button.js
@@ -67,6 +67,8 @@ class QualityMenuButton extends MenuButton {
     this.qualityLevels_ = player.qualityLevels();
 
     this.update = this.update.bind(this);
+    this.hide_ = this.hide_.bind(this);
+    this.show_ = this.show_.bind(this);
 
     this.handleQualityChange_ = this.handleQualityChange_.bind(this);
     this.changeHandler_ = () => {
@@ -83,6 +85,8 @@ class QualityMenuButton extends MenuButton {
     this.on(this.qualityLevels_, 'removequalitylevel', this.update);
     this.on(this.qualityLevels_, 'change', this.handleQualityChange_);
     this.one(this.qualityLevels_, 'change', this.changeHandler_);
+    player.on('adstart', this.hide_);
+    player.on(['adend', 'adtimeout'], this.show_);
 
     this.update();
 
@@ -91,6 +95,8 @@ class QualityMenuButton extends MenuButton {
       this.off(this.qualityLevels_, 'removequalitylevel', this.update);
       this.off(this.qualityLevels_, 'change', this.handleQualityChange_);
       this.off(this.qualityLevels_, 'change', this.changeHandler_);
+      player.off('adstart', this.hide_);
+      player.off(['adend', 'adtimeout'], this.show_);
     });
   }
 
@@ -327,6 +333,24 @@ class QualityMenuButton extends MenuButton {
         this.autoMenuItem_.subLabel_.innerHTML = '';
       }
     }
+  }
+
+  /**
+   * Hide the quality menu button
+   *
+   * @method hideMenu_
+   */
+  hide_() {
+    this.addClass('vjs-hidden');
+  }
+
+  /**
+   * Show the quality menu button
+   *
+   * @method show_
+   */
+  show_() {
+    this.removeClass('vjs-hidden');
   }
 }
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -57,6 +57,53 @@ QUnit.test('registers itself with video.js', function(assert) {
   );
 });
 
+QUnit.test('Hides and shows the component when an ad plays', function(assert) {
+  this.player.qualityMenu();
+
+  // Tick the clock forward enough to trigger the player to be "ready".
+  this.clock.tick(1);
+
+  const levels = this.player.qualityLevels();
+  const button = this.player.getChild('controlBar').getChild('QualityMenuButton');
+
+  assert.equal(button.items.length, 0, 'no menu items when empty quality level list');
+
+  // add multiple quality levels so button displays.
+  levels.addQualityLevel({
+    id: '1',
+    bandwidth: 2000001,
+    width: 500,
+    height: 500,
+    enabled: () => {}
+  });
+  levels.addQualityLevel({
+    id: '2',
+    bandwidth: 3000001,
+    width: 600,
+    height: 600,
+    enabled: () => {}
+  });
+
+  assert.notOk(
+    button.hasClass('vjs-hidden'),
+    'the plugin is displayed'
+  );
+
+  this.player.trigger('adstart');
+
+  assert.ok(
+    button.hasClass('vjs-hidden'),
+    'the plugin is hidden'
+  );
+
+  this.player.trigger('adend');
+
+  assert.notOk(
+    button.hasClass('vjs-hidden'),
+    'the plugin is no longer hidden'
+  );
+});
+
 QUnit.test('Groups QualityLevels by bitrate when useResolutionLabels is false', function(assert) {
   this.player.qualityMenu({ useResolutionLabels: false });
   // Tick the clock forward enough to trigger the player to be "ready".


### PR DESCRIPTION
This change ensures that the quality menu does not appear during ads. We do not want to be able to change quality while an ad is playing.

Changes
- Internal methods to hide and show the menu button
- Listeners for the ad events for when we want to hide/show the menu button.
- Tests