### PR TITLE
fix: update show and hide usage

### DIFF
--- a/src/quality-menu-button.js
+++ b/src/quality-menu-button.js
@@ -68,7 +68,6 @@ class QualityMenuButton extends MenuButton {
 
     this.update = this.update.bind(this);
     this.hide = this.hide.bind(this);
-    this.show = this.show.bind(this);
 
     this.handleQualityChange_ = this.handleQualityChange_.bind(this);
     this.changeHandler_ = () => {
@@ -86,7 +85,7 @@ class QualityMenuButton extends MenuButton {
     this.on(this.qualityLevels_, 'change', this.handleQualityChange_);
     this.one(this.qualityLevels_, 'change', this.changeHandler_);
     player.on('adstart', this.hide);
-    player.on(['adend', 'adtimeout'], this.show);
+    player.on(['adend', 'adtimeout'], this.update);
 
     this.update();
 
@@ -96,7 +95,7 @@ class QualityMenuButton extends MenuButton {
       this.off(this.qualityLevels_, 'change', this.handleQualityChange_);
       this.off(this.qualityLevels_, 'change', this.changeHandler_);
       player.off('adstart', this.hide);
-      player.off(['adend', 'adtimeout'], this.show);
+      player.off(['adend', 'adtimeout'], this.update);
     });
   }
 

--- a/src/quality-menu-button.js
+++ b/src/quality-menu-button.js
@@ -67,8 +67,8 @@ class QualityMenuButton extends MenuButton {
     this.qualityLevels_ = player.qualityLevels();
 
     this.update = this.update.bind(this);
-    this.hide_ = this.hide_.bind(this);
-    this.show_ = this.show_.bind(this);
+    this.hide = this.hide.bind(this);
+    this.show = this.show.bind(this);
 
     this.handleQualityChange_ = this.handleQualityChange_.bind(this);
     this.changeHandler_ = () => {
@@ -85,8 +85,8 @@ class QualityMenuButton extends MenuButton {
     this.on(this.qualityLevels_, 'removequalitylevel', this.update);
     this.on(this.qualityLevels_, 'change', this.handleQualityChange_);
     this.one(this.qualityLevels_, 'change', this.changeHandler_);
-    player.on('adstart', this.hide_);
-    player.on(['adend', 'adtimeout'], this.show_);
+    player.on('adstart', this.hide);
+    player.on(['adend', 'adtimeout'], this.show);
 
     this.update();
 
@@ -95,8 +95,8 @@ class QualityMenuButton extends MenuButton {
       this.off(this.qualityLevels_, 'removequalitylevel', this.update);
       this.off(this.qualityLevels_, 'change', this.handleQualityChange_);
       this.off(this.qualityLevels_, 'change', this.changeHandler_);
-      player.off('adstart', this.hide_);
-      player.off(['adend', 'adtimeout'], this.show_);
+      player.off('adstart', this.hide);
+      player.off(['adend', 'adtimeout'], this.show);
     });
   }
 
@@ -333,24 +333,6 @@ class QualityMenuButton extends MenuButton {
         this.autoMenuItem_.subLabel_.innerHTML = '';
       }
     }
-  }
-
-  /**
-   * Hide the quality menu button
-   *
-   * @method hideMenu_
-   */
-  hide_() {
-    this.addClass('vjs-hidden');
-  }
-
-  /**
-   * Show the quality menu button
-   *
-   * @method show_
-   */
-  show_() {
-    this.removeClass('vjs-hidden');
   }
 }
 


### PR DESCRIPTION
Based on the comment here: https://github.com/videojs/videojs-contrib-quality-menu/pull/10#discussion_r1580052298

Cleanup removing unnecessary hide/show functions.

Also use `update` instead of show, so we conditionally show the menu based on other factors, like the amount of items