### PR TITLE
fix: 'loadedmetadata' event sometimes does not fire as expected when using `defaultResolution` option

### DIFF
--- a/src/quality-menu-button.js
+++ b/src/quality-menu-button.js
@@ -76,6 +76,8 @@ class QualityMenuButton extends MenuButton {
     this.on(this.qualityLevels_, 'addqualitylevel', this.update);
     this.on(this.qualityLevels_, 'removequalitylevel', this.update);
     this.on(this.qualityLevels_, 'change', this.handleQualityChange_);
+
+    // TODO: Remove this and the `defaultResolution` option once videojs/http-streaming supports comparable functionality
     this.one(this.qualityLevels_, 'change', this.firstChangeHandler_);
     player.on('adstart', this.hide);
     player.on(['adend', 'adtimeout'], this.update);

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -587,6 +587,8 @@ QUnit.test('Passing default "HD/SD" quality level selects correct starting level
   });
 
   levels.selectedIndex_ = 3;
+  this.player.readyState = () => 1;
+
   videojs.trigger(levels, 'change');
 
   const items = button.items;
@@ -674,6 +676,8 @@ QUnit.test('Passing default resolution quality level selects correct starting le
   });
 
   levels.selectedIndex_ = 3;
+  this.player.readyState = () => 1;
+
   videojs.trigger(levels, 'change');
 
   const items = button.items;


### PR DESCRIPTION
## Description
This is a hot fix for an issue that has been observed when playing demuxed content with videojs/http-streaming. The browser requires that the first video and audio segment have been successfully fetched prior to firing the 'loadedmetadata' event. However, initiating a fast quality switch after selecting the initial playlist but before metadata has been loaded can result in cancelling pending segment requests, causing one of the audio or video segments not to be fetched, and 'loadedmetadata' not to fire as expected.

## Specific Additions
When we receive the first 'change' event for the initial playlist selection, query the ready state of the player and defer the quality switch to the `defaultResolution` until after 'loadedmetadata' if it has not occurred yet and we expect one prior to playback.

## Important Note
This UI plugin should really not be responsible for disabling ABR and selecting an initial rendition, which is what the `defaultResolution` option does. In a future major version of this plugin we will remove this feature and add the functionality to videojs/http-streaming